### PR TITLE
优化字符串解析和自动补全默认设置，添加语法着色颜色定义

### DIFF
--- a/src/EasyCon2/Config/ControllerConfig.cs
+++ b/src/EasyCon2/Config/ControllerConfig.cs
@@ -11,7 +11,7 @@ public record ConfigState
     public string ChannelToken { get; set; } = string.Empty;
     public bool EnableAlertToken { get; set; } = false;
     public bool EnableChannelToken { get; set; } = false;
-    public bool EnableAutoCompletion { get; set; } = true;
+    public bool EnableAutoCompletion { get; set; } = false;
 
     public bool ChannelControl { get; set; } = false;
 

--- a/src/EasyCon2/Resources/ecp.xshd
+++ b/src/EasyCon2/Resources/ecp.xshd
@@ -2,10 +2,13 @@
         xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
 	<Color name="Comment" foreground="Green" />
 	<Color name="String" foreground="#fff99157" />
-	<Color name="NumberLiteral" foreground="#ff99cc99"/>
+	<Color name="NumberLiteral" foreground="#ff9966ff"/>
 	<Color name="Keywords" fontWeight="bold" foreground="Blue" />
 	<Color name="Funcs" fontWeight="bold" foreground="LightBlue" />
 	<Color name="GamePadKey" fontWeight="bold" foreground="Red" />
+	<Color name="Variable" foreground="#ffcc6600" />
+	<Color name="CaptureVariable" foreground="#ffcc66cc" />
+	<Color name="Constant" foreground="#ff996633" />
 
 	<RuleSet name="CommentMarkerSet">
 		<Keywords fontWeight="bold" foreground="#fff2777a">
@@ -26,6 +29,14 @@
 			<Begin>"</Begin>
 			<End>"</End>
 		</Span>
+
+		<!-- 变量和常量必须在关键字之前匹配 -->
+		<Rule color="Variable">\$[\w]+</Rule>
+		<Rule color="CaptureVariable">\@[\w]+</Rule>
+		<Rule color="Constant">_[\w]+</Rule>
+
+		<!-- 数字 -->
+		<Rule color="NumberLiteral">\b\d+(\.\d+)?([eE][+-]?\d+)?</Rule>
 
 		<Keywords color="Keywords">
 			<Word>IMPORT</Word>


### PR DESCRIPTION
- ControllerConfig: 禁用自动补全默认选项
- 语法着色: 添加变量($)、常量(_)、截图变量(@)以及数字的颜色定义和规则