### PR TITLE
fix: 将 标准差匹配-透明背景 加入搜索方法下拉菜单

### DIFF
--- a/src/EasyCon.Capture/ImgLabel.cs
+++ b/src/EasyCon.Capture/ImgLabel.cs
@@ -179,9 +179,25 @@ public static class ILExt
             }
             else
             {
-                byte[] imageBytes = Convert.FromBase64String(self.ImgBase64);
-                using var target = imageBytes.ToMat();
-                result = ECSearch.FindPic(range, target, self.searchMethod, out md);
+                if (self.searchMethod == SearchMethod.MaskedSqDiffNormed)
+                {
+                    byte[] imageBytes = Convert.FromBase64String(self.ImgBase64);
+                    using var targetRGBA = Cv2.ImDecode(imageBytes, ImreadModes.Unchanged);
+                    if (targetRGBA.Channels() != 4)
+                        throw new Exception("Masked matching requires RGBA image");
+                    Cv2.Split(targetRGBA, out var channels);
+                    using var bgr = new Mat();
+                    Cv2.Merge([channels[0], channels[1], channels[2]], bgr);
+                    using var mask = channels[3];
+                    var pt = MatchFacts.MatchTemplateMasked(range, bgr, mask, out md);
+                    result = [new Point(pt.X, pt.Y)];
+                }
+                else
+                {
+                    byte[] imageBytes = Convert.FromBase64String(self.ImgBase64);
+                    using var target = imageBytes.ToMat();
+                    result = ECSearch.FindPic(range, target, self.searchMethod, out md);
+                }
             }
             md *= 100;
 

--- a/src/EasyCon.Capture/MatchFacts.cs
+++ b/src/EasyCon.Capture/MatchFacts.cs
@@ -8,6 +8,16 @@ internal static class MatchFacts
     /// <summary>
     /// 简化的字符串匹配度计算，使用编辑距离方法
     /// </summary>
+    public static Point MatchTemplateMasked(Mat big, Mat small, Mat mask, out double matchDegree)
+    {
+        matchDegree = 0;
+        using var result = new Mat();
+        Cv2.MatchTemplate(big, small, result, TemplateMatchModes.SqDiffNormed, mask);
+        Cv2.MinMaxLoc(result, out double min, out double max, out var minLoc, out var maxLoc);
+        matchDegree = (1 - min) / 1.0;
+        return minLoc;
+    }
+
     public static Point MatchTemplate(Mat big, Mat small, SearchMethod method, out double matchDegree)
     {
         matchDegree = 0;

--- a/src/EasyCon.Capture/Search.cs
+++ b/src/EasyCon.Capture/Search.cs
@@ -15,6 +15,7 @@ public sealed class ECSearch
             SearchMethod.SqDiffNormed,
             SearchMethod.CCorrNormed,
             SearchMethod.CCoeffNormed,
+            SearchMethod.MaskedSqDiffNormed,
             SearchMethod.EdgeDetectXY,
             SearchMethod.EdgeDetectLaplacian,
             SearchMethod.TesserDetect,

--- a/src/EasyCon.Capture/SearchMethod.cs
+++ b/src/EasyCon.Capture/SearchMethod.cs
@@ -28,11 +28,13 @@ public enum SearchMethod
     EdgeDetectLaplacian = 12,
     [Description("Canny边缘检测")]
     EdgeDetectCanny = 13,
+    [Description("透明背景标准差匹配")]
+    MaskedSqDiffNormed = 14,
     [Description("OCR单行文本识别")]
     TesserDetect = 107,
 }
 
 public static class SearchMethodExtension
 {
-    public static bool IsImageMethod(this SearchMethod method) => method <= SearchMethod.EdgeDetectLaplacian;
+    public static bool IsImageMethod(this SearchMethod method) => method <= SearchMethod.EdgeDetectLaplacian || method == SearchMethod.MaskedSqDiffNormed;
 }


### PR DESCRIPTION
- 新增 SearchMethod.MaskedSqDiffNormed(标准差匹配-透明背景) 标签搜索方法
- 新增 770个火红叶绿普通/异色宝可梦识图标签，386 * 2，未知图腾除外